### PR TITLE
added delete task to frontend

### DIFF
--- a/src/services/Client/TaskService.tsx
+++ b/src/services/Client/TaskService.tsx
@@ -21,6 +21,9 @@ const TaskService = {
         console.log(task);
         return client.put(`/${id}`, task);
     },
+    async deleteTask(id: string) {
+        return client.delete(`/${id}`);
+    },
 };
 
 export { TaskService };


### PR DESCRIPTION
This pull request introduces a feature to delete tasks from the Task Management page. It includes changes to the UI to add delete buttons and the implementation of the delete functionality using React Query.

### UI Enhancements:
* Added delete, edit, and view buttons to the task cards and table rows in the Task Management page (`src/pages/TaskManagementPage/index.tsx`). [[1]](diffhunk://#diff-03a3c32d1369051147fd585983d9cd593c697035e3e3e3b14a4dc54c05df60c4R239-R252) [[2]](diffhunk://#diff-03a3c32d1369051147fd585983d9cd593c697035e3e3e3b14a4dc54c05df60c4R276) [[3]](diffhunk://#diff-03a3c32d1369051147fd585983d9cd593c697035e3e3e3b14a4dc54c05df60c4R288-R303)
* Imported necessary icons for the new buttons (`src/pages/TaskManagementPage/index.tsx`).

### Task Deletion Functionality:
* Implemented `handleDeleteTask` function to confirm and trigger task deletion (`src/pages/TaskManagementPage/index.tsx`).
* Added `deleteTaskMutation` using React Query to handle the task deletion process, including optimistic updates and error handling (`src/pages/TaskManagementPage/index.tsx`).
* Added `deleteTask` method to `TaskService` to make the API call for deleting a task (`src/services/Client/TaskService.tsx`).